### PR TITLE
Rename todo-docs to todo-project in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,7 @@ As a [type of user], I want [goal] so that [reason].
 ## Affected Projects
 - [ ] todo-api
 - [ ] todo-web
-- [ ] todo-docs
+- [ ] todo-project
 
 ## Additional Context
 Any other details, mockups, or references.


### PR DESCRIPTION
## Summary
- Updates the feature request issue template to reflect the GitHub repo rename from `todo-docs` to `todo-project`

## Test plan
- [ ] Issue template shows `todo-project` in the Affected Projects checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)