### PR TITLE
Add black-box Playwright e2e tests for todos list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # API base URL for the todo-api REST endpoints
-NEXT_PUBLIC_API_BASE_URL=http://localhost:5000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5001
 
 # GraphQL endpoint for the todo-api
-NEXT_PUBLIC_GRAPHQL_URL=http://localhost:5000/graphql
+NEXT_PUBLIC_GRAPHQL_URL=http://localhost:5001/graphql

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 .next/
 out/
 *.tsbuildinfo
+
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/e2e/todos.spec.ts
+++ b/tests/e2e/todos.spec.ts
@@ -1,1 +1,44 @@
 // End-to-end tests for todo workflows. Playwright tests covering create, read, update, and delete flows.
+import { test, expect } from '@playwright/test';
+
+const API_BASE = 'http://localhost:5001';
+
+async function createTodo(title: string): Promise<{ id: number }> {
+  const res = await fetch(`${API_BASE}/api/todos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  return res.json();
+}
+
+async function deleteTodo(id: number): Promise<void> {
+  await fetch(`${API_BASE}/api/todos/${id}`, { method: 'DELETE' });
+}
+
+test.describe('todos list page', () => {
+  test('shows empty state when there are no todos', async ({ page }) => {
+    await page.goto('/todos');
+    await expect(page.getByText('No todos yet. Create one to get started!')).toBeVisible();
+  });
+
+  test.describe('with todos', () => {
+    const createdIds: number[] = [];
+
+    test.beforeEach(async () => {
+      const todo = await createTodo('Buy groceries');
+      createdIds.push(todo.id);
+    });
+
+    test.afterEach(async () => {
+      for (const id of createdIds.splice(0)) {
+        await deleteTodo(id);
+      }
+    });
+
+    test('displays todos fetched from the API', async ({ page }) => {
+      await page.goto('/todos');
+      await expect(page.getByText('Buy groceries')).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `playwright.config.ts` with no `webServer` config — assumes both `todo-api` and `todo-web` are already running
- Implements e2e tests covering the current state of the app: empty state and API-driven list rendering
- Seeds/cleans test data via the API directly to keep tests isolated
- Sets `workers: 1` since tests run against shared live state
- Updates `.env.example` and pins `next dev` to port 3000 in `package.json`

Closes #14

## Test plan

- [ ] Start both services (`overmind start` or manually)
- [ ] Run `pnpm test:e2e` — both tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)